### PR TITLE
Move @4c/tsconfig to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "devDependencies": {
     "@4c/cli": "^2.1.8",
     "@4c/jest-preset": "^1.5.0",
+    "@4c/tsconfig": "^0.3.1",
     "@babel/cli": "^7.7.4",
     "@babel/core": "^7.9.6",
     "@babel/preset-env": "^7.12.11",
@@ -57,7 +58,6 @@
     "react-dom": "^16.8.6"
   },
   "dependencies": {
-    "@4c/tsconfig": "^0.3.1",
     "@restart/hooks": "^0.3.22",
     "@types/classnames": "^2.2.9",
     "@types/react": "^16.9.34",


### PR DESCRIPTION
@mbrookes Is experimenting with a live editor for the documentation Material-UI in https://github.com/mui-org/material-ui/pull/24640. Running the branch locally, I have noticed this warning:

<img width="1320" alt="Capture d’écran 2021-01-31 à 20 44 49" src="https://user-images.githubusercontent.com/3165635/106395945-475fb200-6405-11eb-8269-4c7ccfefc378.png">

Looking closer, it seems that the dependency used for dev purposes only.

On a side note, we have a couple of issues standing, we will likely contribute back more here and in react-simple-code-editor, e.g. React 17